### PR TITLE
Fixes syntax for GITHUB_TOKEN assignment in CI workflow

### DIFF
--- a/.github/workflows/ci.svc.yaml
+++ b/.github/workflows/ci.svc.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           version: 3.x
         env:
-          GITHUB_TOKEN:${{ steps.generate-token.outputs.token || github.token }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token || github.token }}
 
       - name: Set up environment
         run: |


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes syntax for GITHUB_TOKEN

**Which issue(s) this PR fixes**:
Fixes #
Fixes syntax for GITHUB_TOKEN
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
