### PR TITLE
docs: Add Code of Conduct link and EU funding logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,4 @@ We as members, contributors, and leaders pledge to make participation in our com
 
 Copyright (20xx-)20xx SAP SE or an SAP affiliate company and <your-project> contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/openkcm/<your-project>).
 
-
-## Code of Conduct
-
-To facilitate a nice environment for all, check out our [Code of Conduct](https://github.com/openkcm/.github/blob/main/CODE_OF_CONDUCT.md).
-
-<p align="center"><img alt="Bundesministerium für Wirtschaft und Energie (BMWE)-EU funding logo" src="https://apeirora.eu/assets/img/BMWK-EU.png" width="400"/></p>
+<p align="center"><img alt="Bundesministerium für Wirtschaft und Klimaschutz (BMWK)-EU funding logo" src="https://apeirora.eu/assets/img/BMWK-EU.png" width="400"/></p>

--- a/README.md
+++ b/README.md
@@ -70,3 +70,10 @@ We as members, contributors, and leaders pledge to make participation in our com
 ## Licensing
 
 Copyright (20xx-)20xx SAP SE or an SAP affiliate company and <your-project> contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/openkcm/<your-project>).
+
+
+## Code of Conduct
+
+To facilitate a nice environment for all, check out our [Code of Conduct](https://github.com/openkcm/.github/blob/main/CODE_OF_CONDUCT.md).
+
+<p align="center"><img alt="Bundesministerium für Wirtschaft und Energie (BMWE)-EU funding logo" src="https://apeirora.eu/assets/img/BMWK-EU.png" width="400"/></p>


### PR DESCRIPTION
This PR adds a link to the Code of Conduct and the EU funding logo to the README.